### PR TITLE
makes miniNExT compatible to mininet 2.3.0

### DIFF
--- a/examples/quagga-ixp/topo.py
+++ b/examples/quagga-ixp/topo.py
@@ -17,12 +17,10 @@ class QuaggaTopo(Topo):
 
     "Creates a topology of Quagga routers"
 
-    def __init__(self):
+    def build(self):
         """Initialize a Quagga topology with 5 routers, configure their IP
            addresses, loop back interfaces, and paths to their private
            configuration directories."""
-        Topo.__init__(self)
-
         # Directory where this file / script is located"
         selfPath = os.path.dirname(os.path.abspath(
             inspect.getfile(inspect.currentframe())))  # script directory
@@ -74,4 +72,4 @@ class QuaggaTopo(Topo):
                                 nodeConfig=quaggaSvcConfig)
 
             # Attach the quaggaContainer to the IXP Fabric Switch
-            self.addLink(quaggaContainer, ixpfabric)
+            self.addLink(quaggaContainer, ixpfabric, fast=False)

--- a/examples/quagga-ixp/topo.py
+++ b/examples/quagga-ixp/topo.py
@@ -72,4 +72,8 @@ class QuaggaTopo(Topo):
                                 nodeConfig=quaggaSvcConfig)
 
             # Attach the quaggaContainer to the IXP Fabric Switch
+            # NOTE: needs the fast=False parameter to work on mininet > 2.2
+            # The fast path in mininet passes namens to ip instead of
+            # bringing up the interfaces and moving them to namespaces.
+            # That approach fails when processes are in separate PID ns
             self.addLink(quaggaContainer, ixpfabric, fast=False)

--- a/mininext/node.py
+++ b/mininext/node.py
@@ -81,7 +81,7 @@ class Node(BaseNode):
                 'bash', '--norc', '-is', 'mininet:' + self.name ]
         master, slave = pty.openpty()
         self.shell = Popen(cmd, stdin=slave, stdout=slave, stderr=slave,
-                           close_fds=True)
+                           close_fds=False)
         self.stdin = os.fdopen( master, 'rw')
         self.stdout = self.stdin
         self.pid = self.shell.pid
@@ -112,9 +112,8 @@ class Node(BaseNode):
                 break
             self.pollOut.poll()
         self.waiting = False
-        self.cmd( 'stty -echo' )
-        self.cmd( 'set +m' )
-
+        # +m: disable job control notification
+        self.cmd( 'unset HISTFILE; stty -echo; set +m' )
 
     # Override on popen() to support mount and PID namespaces
     def popen(self, *args, **kwargs):

--- a/mininext/node.py
+++ b/mininext/node.py
@@ -451,4 +451,5 @@ class Node(BaseNode):
 
 
 class Host(Node):
-
+    "MiniNExT enabled host"
+    pass

--- a/mininext/topo.py
+++ b/mininext/topo.py
@@ -25,7 +25,8 @@ class Topo(BaseTopo):
            returns: host name"""
         if not opts and self.hopts:
             opts = self.hopts
-        opts['cls'] = Host
+        if 'cls' not in opts:
+            opts['cls'] = Host
         return BaseTopo.addNode(self, name, **opts)
 
     # Configure a loopback interface

--- a/mininext/topo.py
+++ b/mininext/topo.py
@@ -17,7 +17,7 @@ class Topo(BaseTopo):
         BaseTopo.__init__(self, **opts)
 
     # Override addHost so that constructor defaults to MiniNExT host
-    def addHost(self, name, cls=Host, **opts):
+    def addHost(self, name, **opts):
         """Adds a host using the MiniNExT host constructor.
            name: host name
            cls: host constructor
@@ -25,7 +25,8 @@ class Topo(BaseTopo):
            returns: host name"""
         if not opts and self.hopts:
             opts = self.hopts
-        return BaseTopo.addNode(self, name, cls=cls, **opts)
+        opts['cls'] = Host
+        return BaseTopo.addNode(self, name, **opts)
 
     # Configure a loopback interface
     def addNodeLoopbackIntf(self, node, ip, loNum=None, **opts):


### PR DESCRIPTION
This patches miniNExT to be compatible with current master branch of mininet.

* Fixes issue with console (mininet now uses openpty)
* Few non-functional changes to match current mininet API
* The way interfaces are created in namespaces changed in current mininet. There is now a 'fast' option, that creates the interface with 'namens' as a parameter of 'ip'. The problem with using it on miniNExT is that hosts are now in different PID namespaces, so when trying to bring up the interface pair (e.g. a1-eth0 and s1-eth1), the switch (s1) does not see the host (a1) PID, and fails. This was fixed simply by creating links with the fast=False option, which now creates the interface in universal namespace, and only then moves it to the specified namespace.